### PR TITLE
Move changesets action to a new workflow

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -24,7 +24,7 @@
       "@styled-icons/ionicons-outline",
       "@styled-icons/ionicons-sharp",
       "@styled-icons/ionicons-solid",
-      "@styled-icons/material-filled",
+      "@styled-icons/material",
       "@styled-icons/material-outlined",
       "@styled-icons/material-rounded",
       "@styled-icons/material-sharp",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,6 @@ jobs:
         working-directory: storybook/
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-      - uses: changesets/action@master
-        if: github.ref == 'refs/heads/main' && github.repository == 'styled-icons/styled-icons'
-        with:
-          publish: yarn changeset publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   lint:
     name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+on: push
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.repository == 'styled-icons/styled-icons'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - run: echo "::set-output name=dir::$(yarn cache dir)"
+        id: yarn-cache-dir-path
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-v1-
+      - run: yarn install --frozen-lockfile
+      - uses: changesets/action@master
+        with:
+          publish: yarn release
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "fmt": "prettier --write './**/*.{ts,tsx,js,md,json}'",
     "fmt:check": "prettier --list-different './**/*.{ts,tsx,js,md,json}'",
     "generate": "yarn wsrun -t -m -c generate",
-    "generate:pkg": "find packages -name 'package.built.json' -not -path '*/node_modules/*' -exec bash -c 'mv \"$1\" \"${1%.built.json}\".json' - '{}' \\;"
+    "generate:pkg": "find packages -name 'package.built.json' -not -path '*/node_modules/*' -exec bash -c 'mv \"$1\" \"${1%.built.json}\".json' - '{}' \\;",
+    "release": "yarn build:icons && yarn changeset publish"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.4",


### PR DESCRIPTION
This will execute faster for non-releases (it'll update the release PR immediately, without needing to build icons or run Storybook tests).